### PR TITLE
feat: 新增"我的歌单"功能

### DIFF
--- a/app/src/main/java/com/guang/cloudx/logic/network/MusicNetwork.kt
+++ b/app/src/main/java/com/guang/cloudx/logic/network/MusicNetwork.kt
@@ -113,6 +113,17 @@ object MusicNetwork {
         )
     }
 
+    suspend fun getUserPlayLists(userId: String, cookie: String, offset: Int = 0, limit: Int = 1000): List<PlayList> {
+        val bodyJSON =
+            "{\"uid\":\"$userId\",\"offset\":\"$offset\",\"limit\":\"$limit\",\"e_r\":true,\"header\":\"\"}"
+        val query =
+            "/api/user/playlist-36cd479b6b5-$bodyJSON-36cd479b6b5-${MD5Helper.calculateMD5("nobody/api/user/playlistuse${bodyJSON}md5forencrypt")}"
+        return Decrypt.decryptUserPlayLists(
+            musicService.getUserPlayLists(AESECBHelper.encrypt(query), cookie)
+                .await()
+        )
+    }
+
     private suspend fun <T> Call<T>.await(): T {
 
         return suspendCoroutine { continuation ->

--- a/app/src/main/java/com/guang/cloudx/logic/network/MusicService.kt
+++ b/app/src/main/java/com/guang/cloudx/logic/network/MusicService.kt
@@ -56,5 +56,12 @@ interface MusicService {
         @Field("params") body: String,
         @Header("Cookie") cookie: String
     ): Call<String>
+
+    @FormUrlEncoded
+    @POST("eapi/user/playlist")
+    fun getUserPlayLists(
+        @Field("params") body: String,
+        @Header("Cookie") cookie: String
+    ): Call<String>
 }
 

--- a/app/src/main/java/com/guang/cloudx/logic/repository/Repository.kt
+++ b/app/src/main/java/com/guang/cloudx/logic/repository/Repository.kt
@@ -53,6 +53,16 @@ object Repository {
         }
     }
 
+    fun getUserPlayListsFlow(userId: String, cookie: String, offset: Int = 0, limit: Int = 1000): Flow<Result<List<PlayList>>> = flow {
+        try {
+            val playLists = MusicNetwork.getUserPlayLists(userId, cookie, offset, limit)
+            emit(Result.success(playLists))
+        } catch (e: Exception) {
+            emit(Result.failure(e))
+            e.e()
+        }
+    }.flowOn(Dispatchers.IO)
+
     suspend fun sendCaptcha(phone: String) = MusicNetwork.sendCaptcha(phone)
 
     suspend fun getLoginData(phone: String, captcha: String) = MusicNetwork.getLoginData(phone, captcha)

--- a/app/src/main/java/com/guang/cloudx/logic/utils/Decrypt.kt
+++ b/app/src/main/java/com/guang/cloudx/logic/utils/Decrypt.kt
@@ -198,6 +198,35 @@ object Decrypt {
         return PlayList(name, coverImgUrl, musics, id)
     }
 
+    fun decryptUserPlayLists(encryptedBody: String): List<PlayList> {
+        val decryptedJson = AESECBHelper.decrypt(encryptedBody)
+        val data = JSONObject(decryptedJson)
+
+        if (data.optInt("code") != 200) {
+            throw Exception("Invalid data: ${data.optString("message", "Unknown error")}")
+        }
+
+        return data.optJSONArray("playlist")?.let { playlist ->
+            List(playlist.length()) { i ->
+                val item = playlist.getJSONObject(i)
+                val trackCount = item.optInt("trackCount", 0)
+                PlayList(
+                    name = item.optString("name", ""),
+                    coverImgUrl = item.optString("coverImgUrl", ""),
+                    musics = List(trackCount) {
+                        Music(
+                            name = "",
+                            artists = emptyList(),
+                            album = Album("", 0, ""),
+                            id = 0
+                        )
+                    },
+                    id = item.optLong("id", 0)
+                )
+            }
+        } ?: emptyList()
+    }
+
     fun decryptUserDetail(encryptedBody: String): User {
         val decryptedJson = AESECBHelper.decrypt(encryptedBody)
         val data = JSONObject(decryptedJson).getJSONObject("profile")

--- a/app/src/main/java/com/guang/cloudx/ui/AppNavigation.kt
+++ b/app/src/main/java/com/guang/cloudx/ui/AppNavigation.kt
@@ -5,6 +5,7 @@ sealed class Screen(val route: String) {
     object Login : Screen("login")
     object DownloadManager : Screen("download_manager")
     object Settings : Screen("settings")
+    object MyPlayLists : Screen("my_playlists")
     object Playlist : Screen("playlist/{type}/{id}") {
         fun createRoute(type: String, id: String) = "playlist/$type/$id"
     }

--- a/app/src/main/java/com/guang/cloudx/ui/home/MainActivity.kt
+++ b/app/src/main/java/com/guang/cloudx/ui/home/MainActivity.kt
@@ -45,6 +45,7 @@ import com.guang.cloudx.logic.utils.toast
 import com.guang.cloudx.ui.Screen
 import com.guang.cloudx.ui.downloadManager.DownloadManagerScreen
 import com.guang.cloudx.ui.login.LoginScreen
+import com.guang.cloudx.ui.myPlayLists.MyPlayListsScreen
 import com.guang.cloudx.ui.playList.PlayListScreen
 import com.guang.cloudx.ui.settings.SettingsScreen
 import com.guang.cloudx.ui.ui.theme.CloudXTheme
@@ -150,6 +151,7 @@ class MainActivity : BaseActivity() {
                         composable(Screen.Home.route) {
                             MainActivityContent(
                                 onNavigateToLogin = { navController.navigate(Screen.Login.route) },
+                                onNavigateToMyPlayLists = { navController.navigate(Screen.MyPlayLists.route) },
                                 onNavigateToDownloadManager = { navController.navigate(Screen.DownloadManager.route) },
                                 onNavigateToSettings = { navController.navigate(Screen.Settings.route) },
                                 onNavigateToPlaylist = { type, id ->
@@ -182,6 +184,14 @@ class MainActivity : BaseActivity() {
                                 onThemeChanged = { color, mode ->
                                     currentThemeColor = color
                                     currentDarkMode = mode
+                                }
+                            )
+                        }
+                        composable(Screen.MyPlayLists.route) {
+                            MyPlayListsScreen(
+                                onBackClick = { navController.popBackStack() },
+                                onPlayListClick = { playList ->
+                                    navController.navigate(Screen.Playlist.createRoute("playlist", playList.id.toString()))
                                 }
                             )
                         }
@@ -266,6 +276,7 @@ class MainActivity : BaseActivity() {
     @Composable
     private fun MainActivityContent(
         onNavigateToLogin: () -> Unit,
+        onNavigateToMyPlayLists: () -> Unit,
         onNavigateToDownloadManager: () -> Unit,
         onNavigateToSettings: () -> Unit,
         onNavigateToPlaylist: (String, String) -> Unit
@@ -445,6 +456,10 @@ class MainActivity : BaseActivity() {
 
                         NavItem.ADD_ALBUM -> {
                             showAlbumDialog = true
+                        }
+
+                        NavItem.MY_PLAYLISTS -> {
+                            onNavigateToMyPlayLists()
                         }
 
                         NavItem.SETTINGS -> {

--- a/app/src/main/java/com/guang/cloudx/ui/home/MainScreen.kt
+++ b/app/src/main/java/com/guang/cloudx/ui/home/MainScreen.kt
@@ -448,6 +448,7 @@ private enum class TopBarState {
 enum class NavItem {
     ADD_PLAYLIST,
     ADD_ALBUM,
+    MY_PLAYLISTS,
     DOWNLOAD_MANAGER,
     SETTINGS,
     SUPPORT,
@@ -524,6 +525,15 @@ fun DrawerContent(
             label = { Text("解析专辑", style = MaterialTheme.typography.labelLarge) },
             selected = false,
             onClick = { onNavItemClick(NavItem.ADD_ALBUM) },
+            modifier = Modifier
+                .padding(horizontal = 12.dp)
+                .height(48.dp)
+        )
+        NavigationDrawerItem(
+            icon = { Icon(Icons.AutoMirrored.Outlined.QueueMusic, contentDescription = null) },
+            label = { Text("我的歌单", style = MaterialTheme.typography.labelLarge) },
+            selected = false,
+            onClick = { onNavItemClick(NavItem.MY_PLAYLISTS) },
             modifier = Modifier
                 .padding(horizontal = 12.dp)
                 .height(48.dp)

--- a/app/src/main/java/com/guang/cloudx/ui/myPlayLists/MyPlayListsScreen.kt
+++ b/app/src/main/java/com/guang/cloudx/ui/myPlayLists/MyPlayListsScreen.kt
@@ -1,0 +1,223 @@
+package com.guang.cloudx.ui.myPlayLists
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.QueueMusic
+import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil3.compose.AsyncImage
+import com.guang.cloudx.logic.model.PlayList
+import com.guang.cloudx.logic.utils.SharedPreferencesUtils
+import com.guang.cloudx.ui.home.TooltipIconButton
+
+/**
+ * 我的歌单页面
+ *
+ * @param onBackClick 返回按钮点击回调
+ * @param onPlayListClick 歌单项点击回调，可用于后续跳转到歌单详情
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MyPlayListsScreen(
+    onBackClick: () -> Unit,
+    onPlayListClick: (PlayList) -> Unit = {}
+) {
+    val context = LocalContext.current
+    val prefs = remember { SharedPreferencesUtils(context) }
+    val viewModel: MyPlayListsViewModel = viewModel()
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadMyPlayLists(prefs.getUserId(), prefs.getCookie())
+    }
+
+    MyPlayListsScreenContent(
+        state = state,
+        onBackClick = onBackClick,
+        onRefresh = { viewModel.refresh(prefs.getUserId(), prefs.getCookie()) },
+        onPlayListClick = onPlayListClick
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MyPlayListsScreenContent(
+    state: MyPlayListsUiState,
+    onBackClick: () -> Unit,
+    onRefresh: () -> Unit,
+    onPlayListClick: (PlayList) -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("我的歌单") },
+                navigationIcon = {
+                    TooltipIconButton(
+                        onClick = onBackClick,
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "返回"
+                    )
+                }
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                LazyColumn(
+                    contentPadding = PaddingValues(vertical = 8.dp),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    items(
+                        items = state.playLists,
+                        key = { it.id }
+                    ) { playList ->
+                        MyPlayListItem(
+                            playList = playList,
+                            onClick = { onPlayListClick(playList) },
+                            onLongClick = { /* 预留长按操作 */ }
+                        )
+                    }
+                }
+            }
+
+            // 空状态
+            if (state.playLists.isEmpty() && !state.isLoading && !state.isRefreshing && state.error == null) {
+                EmptyState(
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+
+            // 错误状态
+            if (!state.isLoading && state.error != null) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = state.error,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 单条歌单展示项
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun MyPlayListItem(
+    playList: PlayList,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ElevatedCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick
+            ),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // 封面图
+            AsyncImage(
+                model = playList.coverImgUrl,
+                contentDescription = playList.name,
+                modifier = Modifier
+                    .size(64.dp)
+                    .clip(RoundedCornerShape(8.dp)),
+                contentScale = ContentScale.Crop
+            )
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            // 歌单信息
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = playList.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "${playList.musics.size} 首",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+/**
+ * 空状态提示
+ */
+@Composable
+private fun EmptyState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.QueueMusic,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = "还没有创建歌单 ο(=•ω＜=)ρ⌒☆",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/app/src/main/java/com/guang/cloudx/ui/myPlayLists/MyPlayListsViewModel.kt
+++ b/app/src/main/java/com/guang/cloudx/ui/myPlayLists/MyPlayListsViewModel.kt
@@ -1,0 +1,91 @@
+package com.guang.cloudx.ui.myPlayLists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.guang.cloudx.logic.model.PlayList
+import com.guang.cloudx.logic.repository.Repository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * 我的歌单 UI 状态
+ *
+ * @param playLists 当前展示的歌单列表
+ * @param isLoading 是否正在加载
+ * @param isRefreshing 是否正在下拉刷新
+ * @param error 错误信息，为空表示无错误
+ */
+data class MyPlayListsUiState(
+    val playLists: List<PlayList> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val error: String? = null
+)
+
+/**
+ * 我的歌单 ViewModel
+ *
+ * 从 [Repository] 拉取当前登录用户的歌单列表，UI 层通过 [loadMyPlayLists] 传入 userId 与 cookie。
+ */
+class MyPlayListsViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MyPlayListsUiState())
+    val uiState: StateFlow<MyPlayListsUiState> = _uiState.asStateFlow()
+
+    /**
+     * 加载用户歌单列表。
+     * 已对接 /api/user/playlist，传入当前登录用户的 userId 与 cookie。
+     * 未登录时显示提示信息。
+     */
+    fun loadMyPlayLists(userId: String, cookie: String) {
+        if (userId.isEmpty() || cookie.isEmpty()) {
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    isRefreshing = false,
+                    error = "请先登录",
+                    playLists = emptyList()
+                )
+            }
+            return
+        }
+
+        _uiState.update { it.copy(isLoading = true, isRefreshing = true, error = null) }
+
+        viewModelScope.launch {
+            Repository.getUserPlayListsFlow(userId, cookie).collect { result ->
+                result.fold(
+                    onSuccess = { playLists ->
+                        _uiState.update {
+                            it.copy(
+                                playLists = playLists,
+                                isLoading = false,
+                                isRefreshing = false,
+                                error = null
+                            )
+                        }
+                    },
+                    onFailure = { throwable ->
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                isRefreshing = false,
+                                error = throwable.message ?: "获取歌单失败"
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    /**
+     * 下拉刷新入口
+     */
+    fun refresh(userId: String, cookie: String) {
+        loadMyPlayLists(userId, cookie)
+    }
+}


### PR DESCRIPTION
## 新增"我的歌单"功能

- 对接 `/api/user/playlist` 接口获取当前登录用户的歌单列表
- 新增 `MyPlayListsScreen` 页面，支持列表展示、下拉刷新、空状态与错误提示
- 在 Drawer 导航中添加"我的歌单"入口 ~（不知道用什么图标于是直接复用了解析歌单的）~
- 点击歌单可跳转至对应详情页，与解析歌单功能相同

## 截图
<img width="360" height="800" alt="Screenshot_2026-06-20-18-12-22-089_com guang cloudx" src="https://github.com/user-attachments/assets/9d34e842-d79f-487d-b40c-63e53c1a7f71" />
<img width="360" height="800" alt="Screenshot_2026-06-20-17-57-48-449_com guang cloudx" src="https://github.com/user-attachments/assets/4393c4d8-c8bf-4166-803e-ec7fb4236fe9" />
<img width="360" height="800" alt="Screenshot_2026-06-20-17-58-09-098_com guang cloudx" src="https://github.com/user-attachments/assets/73b0337e-b58a-4bc9-a132-8941267eb6ec" />
<img width="360" height="800" alt="Screenshot_2026-06-20-17-57-55-644_com guang cloudx" src="https://github.com/user-attachments/assets/7ab0e3dd-5053-4de5-8e80-f8eea5a8258c" />
